### PR TITLE
Planning codebase in ROS1 established with modified xarm_ros submodule

### DIFF
--- a/.catkin_workspace
+++ b/.catkin_workspace
@@ -1,0 +1,1 @@
+# This file currently only serves to mark the location of a catkin workspace for tool integration

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+
+# Directories
+build/
+devel/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/xarm/xarm_ros"]
+	path = src/xarm/xarm_ros
+	url = git@github.com:VADER-CMU/xarm_ros.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/xarm/xarm_ros"]
 	path = src/xarm/xarm_ros
 	url = git@github.com:VADER-CMU/xarm_ros.git
+	branch = master


### PR DESCRIPTION
Progress around PR1. This repository right now just contains a submodule, which links to the xarm_ros fork that we modified (which has all the code in it). The main purpose of this PR is just to establish the ros1 version codebase as our main, since we are sure we aren't using ROS2. A future version should further decouple our dependence on the xarm_ros submodule, and hopefully just have a few files here for the planner node, and have the launch/config files defined elsewhere.

To use it, first clone the correct branch:
`git clone --recursive --branch ros1-sandbox git@github.com:VADER-CMU/planning.git`

Then, go to src/xarm/xarm_ros and check out the master branch explicitly:
`git checkout master`

