### PR TITLE
Moved codebase to own source directory, launch file and planning work

### DIFF
--- a/src/vader_planner/CMakeLists.txt
+++ b/src/vader_planner/CMakeLists.txt
@@ -1,0 +1,246 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(vader_planner)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED
+COMPONENTS
+    moveit_core
+    moveit_visual_tools
+    moveit_ros_planning
+    moveit_ros_planning_interface
+    pluginlib
+    geometric_shapes
+    message_generation
+    geometry_msgs
+    std_msgs
+    xarm_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  pose_plan.srv
+  joint_plan.srv
+  exec_plan.srv
+  single_straight_plan.srv
+)
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  std_msgs
+  # Or other packages containing msgs
+)
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES xarm_planner
+ CATKIN_DEPENDS message_runtime geometry_msgs std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+include
+${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/xarm_planner.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/xarm_planner_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_xarm_planner.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)
+
+# add_executable(xarm_simple_planner src/xarm_simple_planner.cpp)
+# add_dependencies(xarm_simple_planner ${${PROJECT_NAME}_EXPORTED_TARGETS})
+# target_link_libraries(xarm_simple_planner ${catkin_LIBRARIES})
+
+add_executable(vader_dual_arm_planner src/vader_dual_arm_planner.cpp)
+add_dependencies(vader_dual_arm_planner ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(vader_dual_arm_planner ${catkin_LIBRARIES})
+
+add_executable(vader_single_arm_planner src/vader_single_arm_planner.cpp)
+add_dependencies(vader_single_arm_planner ${${PROJECT_NAME}_EXPORTED_TARGETS})
+target_link_libraries(vader_single_arm_planner ${catkin_LIBRARIES})
+
+# add_executable(xarm_simple_planner_test src/xarm_simple_planner_test.cpp)
+# add_dependencies(xarm_simple_planner_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
+# add_dependencies(xarm_simple_planner_test xarm_msgs_generate_messages_cpp)
+# target_link_libraries(xarm_simple_planner_test ${catkin_LIBRARIES})
+
+# add_executable(xarm_gripper_planner src/xarm_gripper_planner.cpp)
+# add_dependencies(xarm_gripper_planner ${${PROJECT_NAME}_EXPORTED_TARGETS})
+# target_link_libraries(xarm_gripper_planner ${catkin_LIBRARIES})
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(TARGETS
+  # xarm_simple_planner
+  # xarm_simple_planner_test
+  # xarm_gripper_planner
+  vader_single_arm_planner
+  vader_dual_arm_planner
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/src/vader_planner/ReadMe.md
+++ b/src/vader_planner/ReadMe.md
@@ -1,0 +1,73 @@
+# Package Introduction
+&ensp;&ensp;This package is intended to provide users a demo programming interface to use moveit!, instead of just using the GUI. To use the API better, users are encouraged to go through [Moveit tutorial](http://docs.ros.org/kinetic/api/moveit_tutorials/html/).  
+&ensp;&ensp;Inside the package, 'xarm_simple_planner' is just a basic implementation of the Move_group interface, if higher level configurations (constraints, switch kinematic solver or planners, etc) are needed, user can fully explore Moveit abilities and implement a sofisticated version.  
+&ensp;&ensp;For simplified Chinese instructions: [简体中文版](./ReadMe_cn.md)    
+
+# Usage
+## Launch the simple planner node:
+If you want to try it in simulation, run:
+```bash
+   $ roslaunch xarm_planner xarm_planner_rviz_sim.launch robot_dof:=<7|6|5> robot_type:=<xarm|lite>  add_gripper:=<true|false> add_vacuum_gripper:=<true|false>
+```
+Or, if you would work with real xArm, run:  
+```bash
+   $ roslaunch xarm_planner xarm_planner_realHW.launch robot_ip:=<your controller box LAN IP address> robot_dof:=<7|6|5> robot_type:=<xarm|lite> add_gripper:=<true|false> add_vacuum_gripper:=<true|false>
+```
+Argument 'robot_dof' specifies the number of joints of your xArm (default is 7). 'add_gripper' and 'add_vacuum_gripper' are for the cases with UF end-effector attached, only one end-effector can be attached.   
+
+This node can provide services for planning request in Cartesian target and joint space target. Service definition can be found in srv folder. User can call the services to let planner solve the path to specified target point, and retrieve the boolean result as successful or not. Once the node is launched, user can try in command-line first, something like:  
+
+## For joint-space planning request:  
+```bash
+   $ rosservice call xarm_joint_plan 'target: [1.0, -0.5, 0.0, -0.3, 0.0, 0.0, 0.5]'
+```
+The target elements in this case correspond to each joint target angle in radians, number of elements is same with the DOF.  
+
+## For Cartesian-space point-to-point planning request:  
+```bash
+   $ rosservice call xarm_pose_plan 'target: [[0.28, 0.2, 0.2], [1.0, 0.0, 0.0, 0.0]]'
+```
+The separated fields for Cartesian target correspond to tool frame position (x, y, z) in ***meters*** and orientation ***Quaternions*** (x, y, z, w).  
+Note that this motion is still point-to-point, meaning the trajectory is NOT a straight line.  
+
+## For Cartesian straight line planning request:
+```bash
+   $ rosservice call xarm_straight_plan 'target: [[0.28, 0.2, 0.2], [1.0, 0.0, 0.0, 0.0]]'
+```
+Command data units are the same with above Cartesian pose command. If planned succesfully, end-effector trajectory will be a straight-line in space. Note that the velocity change may not be as expected during execution. Please refer to MoveGroupInterface documentation to make your modifications to the code if necessary.  
+
+After calling the above planning services, a boolean result named 'success' will be returned.  
+
+### Quaternion calculation tips:
+If you are not familiar with conversion from (roll, pitch, yaw) to quaternions, refer to [this page](http://wiki.ros.org/tf2/Tutorials/Quaternions#Think_in_RPY_then_convert_to_quaternion).
+
+## For Execution of planned trajectory:  
+
+***Notice: Use Cartesian planning with special care, since trajectory from Moveit (OMPL) planner can be highly random and not necessarily the optimal (closest) solution, Do check it in Rviz befroe confirm to move!*** 
+
+If solution exists and user want to execute it on the robot, it can be done by  service call (**recommended**) or topic message. 
+
+### Execute by service call (Blocking)
+Call the 'xarm_exec_plan' service with a request data of 'true', the latest planned path will be executed, the service will return after finishing the execution:  
+```bash
+   $ rosservice call xarm_exec_plan 'true'
+```
+
+### Execute by topic (Non-blocking)
+Just publish a message (type: std_msgs/Bool) to the topic "/xarm_planner_exec", the boolean data should be 'true' to launch the execution, it returns immediately and does not wait for finish:  
+```bash
+   $ rostopic pub -1 /xarm_planner_exec std_msgs/Bool 'true'
+```
+
+Alternative way of calling services or publish messages, is to do it programatically. User can refer to ROS [tutorial1](http://wiki.ros.org/ROS/Tutorials/WritingServiceClient%28c%2B%2B%29) and [tutorial2](http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29) to find out how to do it, or refer to the 'xarm_simple_planner_test.cpp' in the src folder as an example.  
+To run the test program ( ***for xArm7 only***, user can modify the command list for other models), after launching the simple planner:
+```bash
+   $ rosrun xarm_planner xarm_simple_planner_test
+```
+The program will execute three hard-coded joint space target, ***MAKE SURE THERE ARE PLENTY SURROUNDING SPACES BEFORE EXECUTING THIS!***
+
+### Visualization of planned trajectory
+Refer to issue [#57](https://github.com/xArm-Developer/xarm_ros/issues/57), now xArm and end-effector descriptions are re-configured to enable the visualization of TCP trajectory upon successful planning. As is shown below:   
+
+![VISUAL_TRAJ1](../doc/visual_traj1.png)
+![VISUAL_TRAJ2](../doc/visual_traj2.png)

--- a/src/vader_planner/launch/_xarm_gazebo_sandbox2.launch
+++ b/src/vader_planner/launch/_xarm_gazebo_sandbox2.launch
@@ -1,0 +1,74 @@
+<launch>
+  <arg name="robot_dof" default="7"/>
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="namespace" default="xarm"/>
+  <arg name="no_gui_plan" default="true" />
+  <arg name="robot_type" default="xarm"/>
+  <arg name="model1300" default="false" />
+
+  <arg name="velocity_control" default="false"/>
+  <arg name="add_other_geometry" default="false"/>
+  <arg name="geometry_type" default="box"/>
+  <arg name="geometry_mass" default="0.1"/>
+  <arg name="geometry_height" default="0.1"/>
+  <arg name="geometry_radius" default="0.1"/>
+  <arg name="geometry_length" default="0.1"/>
+  <arg name="geometry_width" default="0.1"/>
+  <arg name="geometry_mesh_filename" default=""/>
+  <arg name="geometry_mesh_origin_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_origin_rpy" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_rpy" default="'0 0 0'"/>
+
+  <arg name="add_realsense_d435i" default="false" />
+  <arg name="add_d435i_links" default="false" />
+  <arg name="robot_sn" default="" />
+  
+  <!-- Remap the name space so it can send command to gazebo loaded controller -->
+  <!-- this remap must appear BEFORE move_group launch -->
+  <arg name="robot_controller_name" value="$(eval 'xarm7_velo_traj_controller' if arg('velocity_control') else 'xarm7_traj_controller')" />
+  <remap from="/follow_joint_trajectory" to="/$(arg namespace)/$(arg robot_controller_name)/follow_joint_trajectory"/>
+  <arg name="gripper_controller_name" value="$(eval 'gripper_velo_traj_controller' if arg('velocity_control') else 'gripper_traj_controller')" />
+  <remap if="$(arg add_gripper)" from="gripper_controller/follow_joint_trajectory" to="/$(arg namespace)/$(arg gripper_controller_name)/follow_joint_trajectory"/>
+
+  <include file="$(find xarm7_moveit_config)/launch/moveit_rviz_common.launch">
+    <arg name="jnt_stat_source" value="[/$(arg namespace)/joint_states]" />
+    <arg name="load_move_group" value="true" />
+    <arg name="pub_tf" value="false" />
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="robot_sn" value="$(arg robot_sn)"/>
+
+    <arg name="sim_gazebo" value="true"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+    <!-- uhhh -->
+    <arg name="NO_GUI_CTRL" default="true"/>
+
+  </include>
+
+
+  <!-- XARM GAZEBO -->
+  <include file="$(find xarm_gazebo)/launch/xarm7_beside_table.launch">
+  </include>
+
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="xarm_move_group_planner" pkg="xarm_planner" type="xarm_simple_planner" />
+
+</launch>

--- a/src/vader_planner/launch/moveit_real_arm_configurations.launch
+++ b/src/vader_planner/launch/moveit_real_arm_configurations.launch
@@ -1,0 +1,37 @@
+<launch>
+  <arg name="arm_dof" />
+  <arg name="robot_ip" />
+  <arg name="end_effector" default="" />
+  <arg name="show_rviz" default="true" />
+  <arg name="no_gui_plan" default="true" />
+  <arg name="report_type" default="normal" />
+  <arg name="robot_type" default="xarm" />
+  <arg name="ext_ns" default="" />
+  <arg name="model1300" default="false" />
+
+  <!-- lite6 -->
+  <include if="$(eval robot_type == 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + '_moveit_config') + '/launch/realMove_exec.launch')">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <!-- load the default move_group planner (not xarm_simple_planner) -->
+    <arg name="show_rviz" value="$(arg show_rviz)" />
+    <!-- NO_GUI_CTRL means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)" />
+    <arg name="report_type" value="$(arg report_type)" />
+    <arg name="ext_ns" value="$(arg ext_ns)" />
+    <arg name="add_gripper" value="true" if="$(eval end_effector=='_gripper')" />
+    <arg name="add_vacuum_gripper" value="true" if="$(eval end_effector=='_vacuum_gripper')" />
+  </include>
+
+  <!-- xarm -->
+  <include if="$(eval robot_type != 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + arg('end_effector') + '_moveit_config') + '/launch/realMove_exec.launch')">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <!-- load the default move_group planner (not xarm_simple_planner) -->
+    <arg name="show_rviz" value="$(arg show_rviz)" />
+    <!-- NO_GUI_CTRL means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)" />
+    <arg name="report_type" value="$(arg report_type)" />
+    <arg name="ext_ns" value="$(arg ext_ns)" />
+    <arg name="model1300" value="$(arg model1300)" />
+  </include>
+
+</launch>

--- a/src/vader_planner/launch/moveit_sim_configurations.launch
+++ b/src/vader_planner/launch/moveit_sim_configurations.launch
@@ -1,0 +1,43 @@
+<launch>
+  <arg name="arm_dof" />
+  <arg name="end_effector" default="" />
+  <arg name="namespace" default="xarm"/>
+  <arg name="robot_type" default="xarm" />
+  <arg name="model1300" default="false" />
+  <arg name="no_gui_plan" default="true" />
+
+  <!-- lite6 -->
+  <rosparam if="$(eval robot_type == 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + '_moveit_config') + '/config/' + str(arg('robot_type')) + str(arg('arm_dof')) + '_params.yaml')" command="load" ns="$(arg namespace)"/>
+  <include if="$(eval robot_type == 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + '_moveit_config') + '/launch/moveit_rviz_common.launch')">
+    <arg name="jnt_stat_source" value="[/move_group/fake_controller_joint_states]" />
+    <!-- whether to use fake_execution controller to drive the motion -->
+    <arg name="fake_execution" value="true" />
+    <!-- option to publish tf topic or not -->
+    <arg name="pub_tf" value="true" />
+    <!-- NO_GUI_CTRL means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+    <arg name="NO_GUI_CTRL" value="$(arg no_gui_plan)"/>
+    <!-- option to show rviz or not -->
+    <arg name="show_rviz" value="true" />
+    <!-- option to load gripper controller in simulation -->
+    <arg name="add_gripper" value="true" if="$(eval end_effector=='_gripper')" />
+    <arg name="add_vacuum_gripper" value="true" if="$(eval end_effector=='_vacuum_gripper')" />
+  </include>
+
+  <!-- xarm -->
+  <rosparam if="$(eval robot_type != 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + arg('end_effector') + '_moveit_config') + '/config/' + str(arg('robot_type')) + str(arg('arm_dof')) + '_params.yaml')" command="load" ns="$(arg namespace)"/>
+  <include if="$(eval robot_type != 'lite')" file="$(eval find(str(arg('robot_type')) + str(arg('arm_dof')) + arg('end_effector') + '_moveit_config') + '/launch/moveit_rviz_common.launch')">
+    <arg name="jnt_stat_source" value="[/move_group/fake_controller_joint_states]" />
+    <!-- whether to use fake_execution controller to drive the motion -->
+    <arg name="fake_execution" value="true" />
+    <!-- option to publish tf topic or not -->
+    <arg name="pub_tf" value="true" />
+    <!-- NO_GUI_CTRL means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+    <arg name="NO_GUI_CTRL" value="$(arg no_gui_plan)"/>
+    <!-- option to show rviz or not -->
+    <arg name="show_rviz" value="true" />
+    <!-- option to load gripper controller in simulation -->
+    <arg name="gripper_controller" value="true" if="$(eval end_effector=='_gripper')" />
+    <arg name="model1300" value="$(arg model1300)" />
+  </include>
+
+</launch>

--- a/src/vader_planner/launch/planner.rviz
+++ b/src/vader_planner/launch/planner.rviz
@@ -1,0 +1,442 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 84
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Status1
+        - /MotionPlanning1
+        - /MotionPlanning1/Scene Robot1
+        - /MotionPlanning1/Planning Request1
+        - /MotionPlanning1/Planned Path1
+        - /MarkerArray1
+      Splitter Ratio: 0.742560029
+    Tree Height: 809
+  - Class: rviz/Help
+    Name: Help
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Acceleration_Scaling_Factor: 1
+      Class: moveit_rviz_plugin/MotionPlanning
+      Enabled: true
+      Move Group Namespace: ""
+      MoveIt_Allow_Approximate_IK: false
+      MoveIt_Allow_External_Program: false
+      MoveIt_Allow_Replanning: false
+      MoveIt_Allow_Sensor_Positioning: false
+      MoveIt_Goal_Tolerance: 0
+      MoveIt_Planning_Attempts: 10
+      MoveIt_Planning_Time: 5
+      MoveIt_Use_Constraint_Aware_IK: true
+      MoveIt_Warehouse_Host: 127.0.0.1
+      MoveIt_Warehouse_Port: 33829
+      MoveIt_Workspace:
+        Center:
+          X: 0
+          Y: 0
+          Z: 0
+        Size:
+          X: 2
+          Y: 2
+          Z: 2
+      Name: MotionPlanning
+      Planned Path:
+        Color Enabled: false
+        Interrupt Display: false
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          left_finger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_inner_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_outer_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link_base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_finger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_inner_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_outer_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          xarm_gripper_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+        Loop Animation: false
+        Robot Alpha: 0.5
+        Robot Color: 150; 50; 150
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 0.05 s
+        Trail Step Size: 1
+        Trajectory Topic: move_group/display_planned_path
+      Planning Metrics:
+        Payload: 1
+        Show Joint Torques: false
+        Show Manipulability: false
+        Show Manipulability Index: false
+        Show Weight Limit: false
+        TextHeight: 0.0799999982
+      Planning Request:
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0
+        Joint Violation Color: 255; 0; 255
+        Planning Group: xarm7
+        Query Goal State: false
+        Query Start State: false
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planning Scene Topic: move_group/monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 1
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.200000003
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          left_finger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_inner_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_outer_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          link_base:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_finger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_inner_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_outer_knuckle:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          xarm_gripper_base_link:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+        Robot Alpha: 0.5
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+      Velocity_Scaling_Factor: 1
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        left_finger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_inner_knuckle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_outer_knuckle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link_base:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_finger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_inner_knuckle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_outer_knuckle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        xarm_gripper_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /rviz_visual_tools
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 2.00718117
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.113567002
+        Y: 0.105920002
+        Z: 2.23518001e-07
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: -0.265201837
+      Target Frame: world
+      Value: XYOrbit (rviz)
+      Yaw: 6.06495953
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1028
+  Help:
+    collapsed: false
+  Hide Left Dock: false
+  Hide Right Dock: false
+  MotionPlanning:
+    collapsed: false
+  MotionPlanning - Trajectory Slider:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000100000000000002ad000003befc0200000007fb000000100044006900730070006c0061007900730100000028000003be000000d700fffffffb0000000800480065006c00700000000342000000bb0000007300fffffffb0000000a0056006900650077007300000003b0000000b0000000ad00fffffffb0000000c00430061006d00650072006100000002ff000001610000000000000000fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e00670100000374000001890000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004a00fffffffb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000002580000018e0000018300ffffff00000471000003be00000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Views:
+    collapsed: false
+  Width: 1828
+  X: 1997
+  Y: 26

--- a/src/vader_planner/launch/robot_planner_fake.launch
+++ b/src/vader_planner/launch/robot_planner_fake.launch
@@ -1,0 +1,76 @@
+<launch>
+  <arg name="dof" default="7" />
+  <arg name="robot_type" default="xarm" />
+  <arg name="robot_sn" default="" />
+  <arg name="model1300" default="false" />
+  <arg name="limited" default="true" />
+  
+  <arg name="attach_to" default="world" />
+  <arg name="attach_xyz" default="'0 0 0'" />
+  <arg name="attach_rpy" default="'0 0 0'" />
+  
+  <arg name="add_realsense_d435i" default="false" />
+  <arg name="add_d435i_links" default="false" />
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="add_other_geometry" default="false"/>
+  <arg name="geometry_type" default="box"/>
+  <arg name="geometry_mass" default="0.1"/>
+  <arg name="geometry_height" default="0.1"/>
+  <arg name="geometry_radius" default="0.1"/>
+  <arg name="geometry_length" default="0.1"/>
+  <arg name="geometry_width" default="0.1"/>
+  <arg name="geometry_mesh_filename" default=""/>
+  <arg name="geometry_mesh_origin_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_origin_rpy" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_rpy" default="'0 0 0'"/>
+
+  <arg name="ext_ns" default="" />
+  <arg name="sensors_3d" default="false" />
+  <arg name="jnt_stat_pub_rate" default="10" />
+  <!-- no_gui_plan means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+  <arg name="no_gui_plan" default="true" />
+
+  <arg name="robot_dof" value="$(eval arg('dof') if arg('robot_type') == 'xarm' else 6)" />
+
+  <include file="$(find uf_robot_moveit_config)/launch/_robot_moveit_fake.launch">
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)"/>
+    <arg name="dof" value="$(arg robot_dof)"/>
+    <arg name="robot_type" value="$(arg robot_type)"/>
+    <arg name="robot_sn" value="$(arg robot_sn)"/>
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="limited" value="$(arg limited)"/>
+    
+    <arg name="attach_to" value="$(arg attach_to)"/>
+    <arg name="attach_xyz" value="$(arg attach_xyz)"/>
+    <arg name="attach_rpy" value="$(arg attach_rpy)"/>
+    
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+
+    <arg name="ext_ns" value="$(arg ext_ns)" />
+    <arg name="sensors_3d" value="$(arg sensors_3d)" />
+    <arg name="jnt_stat_pub_rate" value="$(arg jnt_stat_pub_rate)"/>
+    
+  </include>
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="xarm_move_group_planner" pkg="xarm_planner" type="xarm_simple_planner" />
+
+</launch>

--- a/src/vader_planner/launch/robot_planner_realmove.launch
+++ b/src/vader_planner/launch/robot_planner_realmove.launch
@@ -1,0 +1,94 @@
+<launch>
+  <arg name="robot_ip" />
+  <arg name="report_type" default="normal" />	
+  <arg name="dof" default="7" />
+  <arg name="robot_type" default="xarm" />
+  <arg name="robot_sn" default="" />
+  <arg name="model1300" default="false" />
+  <arg name="limited" default="true" />
+  <arg name="hw_ns" default="xarm" />
+  <arg name="velocity_control" default="false"/>
+  <arg name="baud_checkset" default="true" />
+	<arg name="default_gripper_baud" default="2000000" />
+
+  <arg name="attach_to" default="world" />
+  <arg name="attach_xyz" default="'0 0 0'" />
+  <arg name="attach_rpy" default="'0 0 0'" />
+
+  <arg name="add_realsense_d435i" default="false" />
+  <arg name="add_d435i_links" default="false" />
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="add_other_geometry" default="false"/>
+  <arg name="geometry_type" default="box"/>
+  <arg name="geometry_mass" default="0.1"/>
+  <arg name="geometry_height" default="0.1"/>
+  <arg name="geometry_radius" default="0.1"/>
+  <arg name="geometry_length" default="0.1"/>
+  <arg name="geometry_width" default="0.1"/>
+  <arg name="geometry_mesh_filename" default=""/>
+  <arg name="geometry_mesh_origin_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_origin_rpy" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_rpy" default="'0 0 0'"/>
+
+  <arg name="ext_ns" default="" />
+  <arg name="sensors_3d" default="false" />
+  <arg name="enforce_limits" default="true" />
+  <arg name="jnt_stat_pub_rate" default="10" />
+  <!-- load the default move_group planner (not xarm_simple_planner) -->
+  <arg name="show_rviz" default="true" />
+  <!-- no_gui_plan means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+  <arg name="no_gui_plan" default="true" />
+
+  <arg name="robot_dof" value="$(eval arg('dof') if arg('robot_type') == 'xarm' else 6)" />
+
+  <remap from="move_group/display_planned_path" to="$(arg ext_ns)/move_group/display_planned_path" />
+  <include file="$(find uf_robot_moveit_config)/launch/_robot_moveit_realmove.launch">
+    <arg name="dof" value="$(arg robot_dof)" />
+    <arg name="robot_type" value="$(arg robot_type)" />
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <arg name="report_type" value="$(arg report_type)" />	
+    <arg name="robot_sn" value="$(arg robot_sn)"/>
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="limited" value="$(arg limited)"/>
+    <arg name="hw_ns" value="$(arg hw_ns)" />
+    <arg name="velocity_control" value="$(arg velocity_control)"/>
+    <arg name="baud_checkset" value="$(arg baud_checkset)" />
+    <arg name="default_gripper_baud" value="$(arg default_gripper_baud)" />
+
+    <arg name="attach_to" value="$(arg attach_to)"/>
+    <arg name="attach_xyz" value="$(arg attach_xyz)"/>
+    <arg name="attach_rpy" value="$(arg attach_rpy)"/>
+    
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+    
+    <arg name="ext_ns" value="$(arg ext_ns)" />
+    <arg name="sensors_3d" value="$(arg sensors_3d)" />
+    <arg name="enforce_limits" value="$(arg enforce_limits)" />
+    <arg name="jnt_stat_pub_rate" value="$(arg jnt_stat_pub_rate)" />
+    <arg name="show_rviz" value="$(arg show_rviz)" />
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)"/>
+
+  </include>
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="xarm_move_group_planner" pkg="xarm_planner" type="xarm_simple_planner" />
+
+</launch>

--- a/src/vader_planner/launch/vader_dual_xarm7_beside_table.launch
+++ b/src/vader_planner/launch/vader_dual_xarm7_beside_table.launch
@@ -1,0 +1,135 @@
+<launch>
+  <arg name="dof" default="7" />
+  <arg name="robot_type" default="xarm" />
+  <arg name="robot_sn" default="" />
+  <arg name="model1300" default="false" />
+  <arg name="limited" default="true" />
+  <arg name="hw_ns" default="xarm"/>
+  <arg name="velocity_control" default="false"/>
+
+  <arg name="attach_to" default="world" />
+  <arg name="attach_xyz" default="'0 0 0'" />
+  <arg name="attach_rpy" default="'0 0 0'" />
+  
+  <arg name="add_realsense_d435i" default="false" />
+  <arg name="add_d435i_links" default="false" />
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="add_other_geometry" default="false"/>
+  <arg name="geometry_type" default="box"/>
+  <arg name="geometry_mass" default="0.1"/>
+  <arg name="geometry_height" default="0.1"/>
+  <arg name="geometry_radius" default="0.1"/>
+  <arg name="geometry_length" default="0.1"/>
+  <arg name="geometry_width" default="0.1"/>
+  <arg name="geometry_mesh_filename" default=""/>
+  <arg name="geometry_mesh_origin_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_origin_rpy" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_rpy" default="'0 0 0'"/>
+
+  <arg name="sensors_3d" default="false" />
+  <arg name="jnt_stat_pub_rate" default="10" />
+
+  <arg name="kinematics_suffix_1" default="" />
+  <arg name="kinematics_suffix_2" default="" />
+
+  <arg name="robot_dof" value="$(eval arg('dof') if arg('robot_type') == 'xarm' else 6)" />
+  <arg name="robot_name" value="$(eval 'uf850' if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))" />
+
+  <!-- Remap the name space so it can send command to gazebo loaded controller -->
+  <!-- this remap must appear BEFORE move_group launch -->
+  <arg if="$(eval arg('robot_type') == 'uf850')" name="robot_controller_name" value="$(eval arg('robot_type') + ('_velo_traj_controller' if arg('velocity_control') else '_traj_controller'))" />
+  <arg unless="$(eval arg('robot_type') == 'uf850')" name="robot_controller_name" value="$(eval str(arg('robot_type')) + str(arg('dof')) + ('_velo_traj_controller' if arg('velocity_control') else '_traj_controller'))" />
+  <remap from="/L_$(arg robot_name)_controller/follow_joint_trajectory" to="/$(arg hw_ns)/L_$(arg robot_controller_name)/follow_joint_trajectory"/>
+  <remap from="/R_$(arg robot_name)_controller/follow_joint_trajectory" to="/$(arg hw_ns)/R_$(arg robot_controller_name)/follow_joint_trajectory"/>
+  <arg name="gripper_controller_name" value="$(eval 'gripper_velo_traj_controller' if arg('velocity_control') else 'gripper_traj_controller')" />
+  <remap if="$(eval arg('add_gripper') and arg('robot_type') != 'lite')" from="L_gripper_controller/follow_joint_trajectory" to="/$(arg hw_ns)/L_$(arg gripper_controller_name)/follow_joint_trajectory"/>
+  <remap if="$(eval arg('add_gripper') and arg('robot_type') != 'lite')" from="R_gripper_controller/follow_joint_trajectory" to="/$(arg hw_ns)/R_$(arg gripper_controller_name)/follow_joint_trajectory"/>
+
+  <include file="$(find uf_robot_moveit_config)/launch/__moveit_rviz_common.launch">
+    <arg name="jnt_stat_source" value="[/$(arg hw_ns)/joint_states]" />
+    <arg name="load_move_group" value="true" />
+    <arg name="pub_tf" value="false" />
+    <arg name="sim_gazebo" value="true"/>
+    <arg name="dual" value="true" />
+    <arg name="no_gui_plan" default="true"/>
+
+
+    <arg name="dof" value="$(arg dof)" />
+    <arg name="robot_type" value="$(arg robot_type)" />
+    <arg name="robot_sn" value="$(arg robot_sn)"/> 
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="limited" value="$(arg limited)"/>
+    <arg name="velocity_control" value="$(arg velocity_control)" />
+
+    <arg name="attach_to" value="$(arg attach_to)"/>
+    <arg name="attach_xyz" value="$(arg attach_xyz)"/>
+    <arg name="attach_rpy" value="$(arg attach_rpy)"/>
+    
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+
+    <arg name="sensors_3d" value="$(arg sensors_3d)" />
+    <arg name="jnt_stat_pub_rate" value="$(arg jnt_stat_pub_rate)" />
+
+    <arg name="kinematics_suffix_1" value="$(arg kinematics_suffix_1)"/>
+    <arg name="kinematics_suffix_2" value="$(arg kinematics_suffix_2)"/>
+
+  </include>
+
+  <include file="$(find xarm_gazebo)/launch/_dual_robot_beside_table.launch">
+    <arg name="dof" value="$(arg dof)" />
+    <arg name="robot_type" value="$(arg robot_type)" />
+    <arg name="robot_sn" value="$(arg robot_sn)"/> 
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="limited" value="$(arg limited)"/>
+    <arg name="hw_ns" value="$(arg hw_ns)"/>
+    <arg name="velocity_control" value="$(arg velocity_control)" />
+
+    <arg name="attach_to" value="$(arg attach_to)"/>
+    <arg name="attach_xyz" value="$(arg attach_xyz)"/>
+    <arg name="attach_rpy" value="$(arg attach_rpy)"/>
+    
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+
+    <arg name="kinematics_suffix_1" value="$(arg kinematics_suffix_1)"/>
+    <arg name="kinematics_suffix_2" value="$(arg kinematics_suffix_2)"/>
+
+  </include>
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <!-- left arm: L_xarm7, right arm: R_xarm7 -->
+  <node name="vader_dual_arm_planner" pkg="vader_planner" type="vader_dual_arm_planner" />
+
+</launch>

--- a/src/vader_planner/launch/vader_xarm_planner_gazebo_rviz.launch
+++ b/src/vader_planner/launch/vader_xarm_planner_gazebo_rviz.launch
@@ -1,0 +1,74 @@
+<launch>
+  <arg name="robot_dof" default="7"/>
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="namespace" default="xarm"/>
+  <arg name="no_gui_plan" default="true" />
+  <arg name="robot_type" default="xarm"/>
+  <arg name="model1300" default="false" />
+
+  <arg name="velocity_control" default="false"/>
+  <arg name="add_other_geometry" default="false"/>
+  <arg name="geometry_type" default="box"/>
+  <arg name="geometry_mass" default="0.1"/>
+  <arg name="geometry_height" default="0.1"/>
+  <arg name="geometry_radius" default="0.1"/>
+  <arg name="geometry_length" default="0.1"/>
+  <arg name="geometry_width" default="0.1"/>
+  <arg name="geometry_mesh_filename" default=""/>
+  <arg name="geometry_mesh_origin_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_origin_rpy" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_xyz" default="'0 0 0'"/>
+  <arg name="geometry_mesh_tcp_rpy" default="'0 0 0'"/>
+
+  <arg name="add_realsense_d435i" default="false" />
+  <arg name="add_d435i_links" default="false" />
+  <arg name="robot_sn" default="" />
+  
+  <!-- Remap the name space so it can send command to gazebo loaded controller -->
+  <!-- this remap must appear BEFORE move_group launch -->
+  <arg name="robot_controller_name" value="$(eval 'xarm7_velo_traj_controller' if arg('velocity_control') else 'xarm7_traj_controller')" />
+  <remap from="/follow_joint_trajectory" to="/$(arg namespace)/$(arg robot_controller_name)/follow_joint_trajectory"/>
+  <arg name="gripper_controller_name" value="$(eval 'gripper_velo_traj_controller' if arg('velocity_control') else 'gripper_traj_controller')" />
+  <remap if="$(arg add_gripper)" from="gripper_controller/follow_joint_trajectory" to="/$(arg namespace)/$(arg gripper_controller_name)/follow_joint_trajectory"/>
+
+  <include file="$(find xarm7_moveit_config)/launch/moveit_rviz_common.launch">
+    <arg name="jnt_stat_source" value="[/$(arg namespace)/joint_states]" />
+    <arg name="load_move_group" value="true" />
+    <arg name="pub_tf" value="false" />
+    <arg name="model1300" value="$(arg model1300)"/>
+    <arg name="add_realsense_d435i" value="$(arg add_realsense_d435i)"/>
+    <arg name="add_d435i_links" value="$(arg add_d435i_links)"/>
+    <arg name="robot_sn" value="$(arg robot_sn)"/>
+
+    <arg name="sim_gazebo" value="true"/>
+    <arg name="add_gripper" value="$(arg add_gripper)"/>
+    <arg name="add_vacuum_gripper" value="$(arg add_vacuum_gripper)"/>
+    <arg name="add_other_geometry" value="$(arg add_other_geometry)"/>
+    <arg name="geometry_type" value="$(arg geometry_type)"/>
+    <arg name="geometry_mass" value="$(arg geometry_mass)"/>
+    <arg name="geometry_height" value="$(arg geometry_height)"/>
+    <arg name="geometry_radius" value="$(arg geometry_radius)"/>
+    <arg name="geometry_length" value="$(arg geometry_length)"/>
+    <arg name="geometry_width" value="$(arg geometry_width)"/>
+    <arg name="geometry_mesh_filename" value="$(arg geometry_mesh_filename)"/>
+    <arg name="geometry_mesh_origin_xyz" value="$(arg geometry_mesh_origin_xyz)"/>
+    <arg name="geometry_mesh_origin_rpy" value="$(arg geometry_mesh_origin_rpy)"/>
+    <arg name="geometry_mesh_tcp_xyz" value="$(arg geometry_mesh_tcp_xyz)"/>
+    <arg name="geometry_mesh_tcp_rpy" value="$(arg geometry_mesh_tcp_rpy)"/>
+    <!-- uhhh -->
+    <arg name="NO_GUI_CTRL" default="true"/>
+
+  </include>
+
+
+  <!-- XARM GAZEBO -->
+  <include file="$(find xarm_gazebo)/launch/xarm7_beside_table.launch">
+  </include>
+
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="vader_single_arm_planner" pkg="vader_planner" type="vader_single_arm_planner" />
+
+</launch>

--- a/src/vader_planner/launch/xarm_planner_realHW.launch
+++ b/src/vader_planner/launch/xarm_planner_realHW.launch
@@ -1,0 +1,35 @@
+<launch>
+
+  <arg name="robot_ip" />
+  
+  <arg name="robot_dof" />
+  <!-- load the default move_group planner (not xarm_simple_planner) -->
+  <arg name="show_rviz" default="true" />
+  <!-- NO_GUI_CTRL means that Rviz configuration is just for display purpose, no (Moveit) control panel loaded -->
+  <arg name="no_gui_plan" default="true" />
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="report_type" default="normal" />
+  <arg name="ext_ns" default="" />
+  <arg name="robot_type" default="xarm"/>
+  <arg name="model1300" default="false" />
+
+  <remap from="move_group/display_planned_path" to="$(arg ext_ns)/move_group/display_planned_path" />
+  <include file="$(find xarm_planner)/launch/moveit_real_arm_configurations.launch">
+    <arg name="arm_dof" value="$(arg robot_dof)" />
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <arg name="end_effector" value="_gripper" if="$(arg add_gripper)" />
+    <arg name="end_effector" value="_vacuum_gripper" if="$(arg add_vacuum_gripper)" />
+    <arg name="report_type" value="$(arg report_type)" />
+    <arg name="ext_ns" value="$(arg ext_ns)" />
+    <arg name="robot_type" value="$(arg robot_type)" />
+    <arg name="model1300" value="$(arg model1300)" />
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)" />
+  </include>
+
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="xarm_move_group_planner" pkg="xarm_planner" type="xarm_simple_planner" />
+
+</launch>
+

--- a/src/vader_planner/launch/xarm_planner_rviz_sim.launch
+++ b/src/vader_planner/launch/xarm_planner_rviz_sim.launch
@@ -1,0 +1,24 @@
+<launch>
+  <arg name="robot_dof" />
+  <arg name="add_gripper" default="false" />
+  <arg name="add_vacuum_gripper" default="false" />
+  <arg name="namespace" default="xarm"/>
+  <arg name="no_gui_plan" default="true" />
+  <arg name="robot_type" default="xarm"/>
+  <arg name="model1300" default="false" />
+
+  <include file="$(find xarm_planner)/launch/moveit_sim_configurations.launch">
+    <arg name="arm_dof" value="$(arg robot_dof)" />
+    <arg name="end_effector" value="_gripper" if="$(arg add_gripper)" />
+    <arg name="end_effector" value="_vacuum_gripper" if="$(arg add_vacuum_gripper)" />
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="robot_type" value="$(arg robot_type)" />
+    <arg name="model1300" value="$(arg model1300)" />
+    <arg name="no_gui_plan" value="$(arg no_gui_plan)" />
+  </include>
+  
+  <param name="robot_name" type="str" value = "$(eval arg('robot_type') if arg('robot_type') == 'uf850' else arg('robot_type') + str(arg('robot_dof')))"/>
+  <!-- bring up the simple planner (based on move_group) that provide plan service and execution server -->
+  <node name="xarm_move_group_planner" pkg="xarm_planner" type="xarm_simple_planner" />
+
+</launch>

--- a/src/vader_planner/package.xml
+++ b/src/vader_planner/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>vader_planner</name>
+  <version>0.0.0</version>
+  <description>The vader_planner package</description>
+
+  <maintainer email="vader@vader.com">TODO</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>pluginlib</build_depend>
+  <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_ros_planning_interface</build_depend>
+  <build_depend>moveit_ros_perception</build_depend>
+  <build_depend>interactive_markers</build_depend>
+  <build_depend>geometric_shapes</build_depend>
+  <build_depend>moveit_visual_tools</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>xarm_msgs</build_depend>
+  <build_depend>tf</build_depend>
+
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>moveit_core</exec_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_ros_planning_interface</exec_depend>
+  <exec_depend>moveit_ros_perception</exec_depend>
+  <exec_depend>interactive_markers</exec_depend>
+  <exec_depend>moveit_visual_tools</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>ros_controllers</exec_depend>
+  <exec_depend>ros_control</exec_depend>
+  <exec_depend>xarm_msgs</exec_depend>
+  <build_depend>tf</build_depend>
+  
+</package>

--- a/src/vader_planner/src/vader_dual_arm_planner.cpp
+++ b/src/vader_planner/src/vader_dual_arm_planner.cpp
@@ -1,0 +1,227 @@
+/* Copyright 2018 UFACTORY Inc. All Rights Reserved.
+ *
+ * Software License Agreement (BSD License)
+ *
+ * Author: Jason Peng <jason@ufactory.cc>
+ ============================================================================*/
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+
+#include <moveit_msgs/DisplayRobotState.h>
+#include <moveit_msgs/DisplayTrajectory.h>
+
+#include <moveit_msgs/AttachedCollisionObject.h>
+#include <moveit_msgs/CollisionObject.h>
+
+#include <moveit_visual_tools/moveit_visual_tools.h>
+#include <std_msgs/Bool.h>
+#include <xarm_planner/pose_plan.h>
+#include <xarm_planner/joint_plan.h>
+#include <xarm_planner/exec_plan.h>
+#include <xarm_planner/single_straight_plan.h>
+
+#define SPINNER_THREAD_NUM 2
+
+/* Used for Cartesian path computation, please modify as needed: */
+const double jump_threshold = 0.0;
+const double eef_step = 0.005;
+const double maxV_scale_factor = 0.3;
+
+const std::string PLANNING_GROUP_L = "L_xarm7";
+const std::string PLANNING_GROUP_R = "R_xarm7";
+
+namespace rvt = rviz_visual_tools;
+
+class VADERPlanner
+{
+  public:
+    VADERPlanner(const std::string plan_group_name):spinner(SPINNER_THREAD_NUM), group(plan_group_name), PLANNING_GROUP(plan_group_name){init();};
+    // VADERPlanner():spinner(SPINNER_THREAD_NUM),group(PLANNING_GROUP){init();};
+    ~VADERPlanner(){ delete visual_tools;};
+    void start();
+    void stop();
+
+
+  private:
+    ros::NodeHandle node_handle;
+    ros::AsyncSpinner spinner;
+    moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
+    std::vector<std::string> joint_names;
+    moveit::planning_interface::MoveGroupInterface group;
+    moveit::planning_interface::MoveGroupInterface::Plan my_xarm_plan;
+    moveit_visual_tools::MoveItVisualTools *visual_tools;
+    std::string left_or_right_arm;
+    std::string PLANNING_GROUP;
+
+    ros::Publisher display_path;
+    ros::ServiceServer plan_pose_srv;
+    ros::ServiceServer plan_joint_srv;
+    ros::ServiceServer sing_cart_srv;
+    ros::Subscriber exec_plan_sub; /* non-blocking*/
+    ros::ServiceServer exec_plan_srv; /* blocking with result feedback */
+
+    void init();
+    bool do_pose_plan(xarm_planner::pose_plan::Request &req, xarm_planner::pose_plan::Response &res);
+    bool do_joint_plan(xarm_planner::joint_plan::Request &req, xarm_planner::joint_plan::Response &res);
+    bool do_single_cartesian_plan(xarm_planner::single_straight_plan::Request &req, xarm_planner::single_straight_plan::Response &res);
+    bool exec_plan_cb(xarm_planner::exec_plan::Request &req, xarm_planner::exec_plan::Response &res);
+    void execute_plan_topic(const std_msgs::Bool::ConstPtr& exec);
+    void show_trail(bool plan_result);
+};
+
+void VADERPlanner::init()
+{
+  joint_names = group.getJointNames();
+
+  display_path = node_handle.advertise<moveit_msgs::DisplayTrajectory>("move_group/display_planned_path", 1, true); /*necessary?*/
+
+  ROS_INFO_NAMED("move_group_planner", "Reference frame: %s", group.getPlanningFrame().c_str());
+
+  ROS_INFO_NAMED("move_group_planner", "End effector link: %s", group.getEndEffectorLink().c_str());
+
+  /* Notice: the correct way to specify member function as callbacks */
+  plan_pose_srv = node_handle.advertiseService(PLANNING_GROUP + "_xarm_pose_plan", &VADERPlanner::do_pose_plan, this);
+  plan_joint_srv = node_handle.advertiseService(PLANNING_GROUP + "_xarm_joint_plan", &VADERPlanner::do_joint_plan, this);
+  sing_cart_srv = node_handle.advertiseService(PLANNING_GROUP + "_xarm_straight_plan", &VADERPlanner::do_single_cartesian_plan, this);
+
+  exec_plan_sub = node_handle.subscribe(PLANNING_GROUP + "_xarm_planner_exec", 10, &VADERPlanner::execute_plan_topic, this);
+  exec_plan_srv = node_handle.advertiseService(PLANNING_GROUP + "_xarm_exec_plan", &VADERPlanner::exec_plan_cb, this);
+
+  visual_tools = new moveit_visual_tools::MoveItVisualTools("link_base");
+  Eigen::Isometry3d text_pose = Eigen::Isometry3d::Identity();
+  text_pose.translation().z() = 0.8;
+  visual_tools->publishText(text_pose, PLANNING_GROUP + "_xArm Planner Demo", rvt::WHITE, rvt::XLARGE);
+  visual_tools->trigger();
+
+}
+
+void VADERPlanner::start()
+{
+  ROS_INFO("Spinning");
+  spinner.start();
+}
+
+void VADERPlanner::stop()
+{
+  spinner.stop();
+}
+
+void VADERPlanner::show_trail(bool plan_result)
+{
+  if(plan_result)
+  {
+    ROS_INFO_NAMED("xarm_planner", "Visualizing plan as trajectory line");
+    
+    visual_tools->deleteAllMarkers();
+    const robot_state::JointModelGroup* joint_model_group = group.getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+    visual_tools->publishTrajectoryLine(my_xarm_plan.trajectory_, joint_model_group);
+    visual_tools->trigger();
+  }
+}
+
+bool VADERPlanner::do_pose_plan(xarm_planner::pose_plan::Request &req, xarm_planner::pose_plan::Response &res)
+{
+  group.setPoseTarget(req.target);
+  
+  ROS_INFO("xarm_planner received new target: [ position: (%f, %f, %f), orientation: (%f, %f, %f, %f)", \
+    req.target.position.x, req.target.position.y, req.target.position.z, req.target.orientation.x, \
+    req.target.orientation.y, req.target.orientation.z, req.target.orientation.w);
+
+  bool success = (group.plan(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  res.success = success;
+  ROS_INFO_NAMED("move_group_planner", "This plan (pose goal) %s", success ? "SUCCEEDED" : "FAILED");
+  
+  show_trail(success);
+
+  return success;
+}
+
+bool VADERPlanner::do_single_cartesian_plan(xarm_planner::single_straight_plan::Request &req, xarm_planner::single_straight_plan::Response &res)
+{
+  std::vector<geometry_msgs::Pose> waypoints;
+  waypoints.push_back(req.target);
+  group.setMaxVelocityScalingFactor(maxV_scale_factor);
+  moveit_msgs::RobotTrajectory trajectory;
+  
+  double fraction = group.computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+  bool success = true;
+  if(fraction<0.9)
+    success = false;
+  else
+  {
+    my_xarm_plan.trajectory_ = trajectory;
+  }
+  fprintf(stderr, "[VADERPlanner::do_single_cartesian_plan(): ] Coverage: %lf\n", fraction);
+
+  res.success = success;
+  show_trail(success);
+  
+  return success;
+
+}
+
+bool VADERPlanner::do_joint_plan(xarm_planner::joint_plan::Request &req, xarm_planner::joint_plan::Response &res)
+{
+  ROS_INFO("move_group_planner received new plan Request");
+  if(!group.setJointValueTarget(req.target))
+  {
+    ROS_ERROR("setJointValueTarget() Failed! Please check the dimension and range of given joint target.");
+    return false;
+  }
+  
+  bool success = (group.plan(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  res.success = success;
+  ROS_INFO_NAMED("move_group_planner", "This plan (joint goal) %s", success ? "SUCCEEDED" : "FAILED");
+  show_trail(success);
+  return success;
+}
+
+bool VADERPlanner::exec_plan_cb(xarm_planner::exec_plan::Request &req, xarm_planner::exec_plan::Response &res)
+{
+  if(req.exec)
+  {
+    ROS_INFO("%s Received Execution Service Request", PLANNING_GROUP.c_str());
+    bool finish_ok = (group.execute(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS); /* return after execution finish */
+    res.success = finish_ok;
+    return finish_ok;
+  }
+
+  res.success = false;
+  return false;
+}
+
+/* execution subscriber call-back function */
+void VADERPlanner::execute_plan_topic(const std_msgs::Bool::ConstPtr& exec)
+{
+  if(exec->data)
+  { 
+    ROS_INFO("%s Received Execution Command !!!!!", PLANNING_GROUP.c_str());
+    group.asyncExecute(my_xarm_plan); /* return without waiting for finish */
+  }
+}
+
+
+// std::string VADERPlanner::PLANNING_GROUP; // Definition of static class member
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "vader_dual_arm_planner");
+  ros::NodeHandle nh;
+  // std::string robot_name1 = "";
+  // nh.getParam("robot_name", robot_name1);
+  // VADERPlanner::PLANNING_GROUP = robot_name1;
+
+  VADERPlanner plannerL(PLANNING_GROUP_L);
+  VADERPlanner plannerR(PLANNING_GROUP_R);
+
+  plannerL.start();
+  plannerR.start();
+  ROS_INFO("Waiting for \'pose_plan\' or \'joint_plan\' service Request ...");
+  //rosservice call L_xarm7_xarm_pose_plan 'target: [[0.28, 0.2, 0.2], [1.0, 0.0, 0.0, 0.0]]'
+  //rosservice call R_xarm7_xarm_pose_plan 'target: [[0.28, 0.8, 0.2], [1.0, 0.0, 0.0, 0.0]]' //right arm is set at [0,1,0] origin, so move target accordingly
+  //rosservice call L_xarm7_xarm_exec_plan 'true'; rosservice call R_xarm7_xarm_exec_plan 'true' //this is sequential.
+
+  ros::waitForShutdown();
+  return 0;
+}
+

--- a/src/vader_planner/src/vader_single_arm_planner.cpp
+++ b/src/vader_planner/src/vader_single_arm_planner.cpp
@@ -1,0 +1,221 @@
+/* Copyright 2018 UFACTORY Inc. All Rights Reserved.
+ *
+ * Software License Agreement (BSD License)
+ *
+ * Author: Jason Peng <jason@ufactory.cc>
+ ============================================================================*/
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+
+#include <moveit_msgs/DisplayRobotState.h>
+#include <moveit_msgs/DisplayTrajectory.h>
+
+#include <moveit_msgs/AttachedCollisionObject.h>
+#include <moveit_msgs/CollisionObject.h>
+
+#include <moveit_visual_tools/moveit_visual_tools.h>
+#include <std_msgs/Bool.h>
+#include <xarm_planner/pose_plan.h>
+#include <xarm_planner/joint_plan.h>
+#include <xarm_planner/exec_plan.h>
+#include <xarm_planner/single_straight_plan.h>
+
+#define SPINNER_THREAD_NUM 2
+
+/* Used for Cartesian path computation, please modify as needed: */
+const double jump_threshold = 0.0;
+const double eef_step = 0.005;
+const double maxV_scale_factor = 0.3;
+
+
+namespace rvt = rviz_visual_tools;
+
+class VADERPlanner
+{
+  public:
+    VADERPlanner(const std::string plan_group_name):spinner(SPINNER_THREAD_NUM), group(plan_group_name){init();};
+    VADERPlanner():spinner(SPINNER_THREAD_NUM),group(PLANNING_GROUP){init();};
+    ~VADERPlanner(){ delete visual_tools;};
+    void start();
+    void stop();
+
+    static std::string PLANNING_GROUP; // declaration of static class member
+
+  private:
+    ros::NodeHandle node_handle;
+    ros::AsyncSpinner spinner;
+    moveit::planning_interface::PlanningSceneInterface planning_scene_interface;
+    std::vector<std::string> joint_names;
+    moveit::planning_interface::MoveGroupInterface group;
+    moveit::planning_interface::MoveGroupInterface::Plan my_xarm_plan;
+    moveit_visual_tools::MoveItVisualTools *visual_tools;
+
+    ros::Publisher display_path;
+    ros::ServiceServer plan_pose_srv;
+    ros::ServiceServer plan_joint_srv;
+    ros::ServiceServer sing_cart_srv;
+    ros::Subscriber exec_plan_sub; /* non-blocking*/
+    ros::ServiceServer exec_plan_srv; /* blocking with result feedback */
+
+    void init();
+    bool do_pose_plan(xarm_planner::pose_plan::Request &req, xarm_planner::pose_plan::Response &res);
+    bool do_joint_plan(xarm_planner::joint_plan::Request &req, xarm_planner::joint_plan::Response &res);
+    bool do_single_cartesian_plan(xarm_planner::single_straight_plan::Request &req, xarm_planner::single_straight_plan::Response &res);
+    bool exec_plan_cb(xarm_planner::exec_plan::Request &req, xarm_planner::exec_plan::Response &res);
+    void execute_plan_topic(const std_msgs::Bool::ConstPtr& exec);
+    void show_trail(bool plan_result);
+};
+
+void VADERPlanner::init()
+{
+  joint_names = group.getJointNames();
+
+  display_path = node_handle.advertise<moveit_msgs::DisplayTrajectory>("move_group/display_planned_path", 1, true); /*necessary?*/
+
+  ROS_INFO_NAMED("move_group_planner", "Reference frame: %s", group.getPlanningFrame().c_str());
+
+  ROS_INFO_NAMED("move_group_planner", "End effector link: %s", group.getEndEffectorLink().c_str());
+
+  /* Notice: the correct way to specify member function as callbacks */
+  plan_pose_srv = node_handle.advertiseService("xarm_pose_plan", &VADERPlanner::do_pose_plan, this);
+  plan_joint_srv = node_handle.advertiseService("xarm_joint_plan", &VADERPlanner::do_joint_plan, this);
+  sing_cart_srv = node_handle.advertiseService("xarm_straight_plan", &VADERPlanner::do_single_cartesian_plan, this);
+
+  exec_plan_sub = node_handle.subscribe("xarm_planner_exec", 10, &VADERPlanner::execute_plan_topic, this);
+  exec_plan_srv = node_handle.advertiseService("xarm_exec_plan", &VADERPlanner::exec_plan_cb, this);
+
+  visual_tools = new moveit_visual_tools::MoveItVisualTools("link_base");
+  Eigen::Isometry3d text_pose = Eigen::Isometry3d::Identity();
+  text_pose.translation().z() = 0.8;
+  visual_tools->publishText(text_pose, "xArm Planner Demo", rvt::WHITE, rvt::XLARGE);
+  visual_tools->trigger();
+
+}
+
+void VADERPlanner::start()
+{
+  ROS_INFO("Spinning");
+  spinner.start();
+}
+
+void VADERPlanner::stop()
+{
+  spinner.stop();
+}
+
+void VADERPlanner::show_trail(bool plan_result)
+{
+  if(plan_result)
+  {
+    ROS_INFO_NAMED("xarm_planner", "Visualizing plan as trajectory line");
+    
+    visual_tools->deleteAllMarkers();
+    const robot_state::JointModelGroup* joint_model_group = group.getCurrentState()->getJointModelGroup(PLANNING_GROUP);
+    visual_tools->publishTrajectoryLine(my_xarm_plan.trajectory_, joint_model_group);
+    visual_tools->trigger();
+  }
+}
+
+bool VADERPlanner::do_pose_plan(xarm_planner::pose_plan::Request &req, xarm_planner::pose_plan::Response &res)
+{
+  group.setPoseTarget(req.target);
+  
+  ROS_INFO("xarm_planner received new target: [ position: (%f, %f, %f), orientation: (%f, %f, %f, %f)", \
+    req.target.position.x, req.target.position.y, req.target.position.z, req.target.orientation.x, \
+    req.target.orientation.y, req.target.orientation.z, req.target.orientation.w);
+
+  bool success = (group.plan(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  res.success = success;
+  ROS_INFO_NAMED("move_group_planner", "This plan (pose goal) %s", success ? "SUCCEEDED" : "FAILED");
+  
+  show_trail(success);
+
+  return success;
+}
+
+bool VADERPlanner::do_single_cartesian_plan(xarm_planner::single_straight_plan::Request &req, xarm_planner::single_straight_plan::Response &res)
+{
+  std::vector<geometry_msgs::Pose> waypoints;
+  waypoints.push_back(req.target);
+  group.setMaxVelocityScalingFactor(maxV_scale_factor);
+  moveit_msgs::RobotTrajectory trajectory;
+  
+  double fraction = group.computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+  bool success = true;
+  if(fraction<0.9)
+    success = false;
+  else
+  {
+    my_xarm_plan.trajectory_ = trajectory;
+  }
+  fprintf(stderr, "[VADERPlanner::do_single_cartesian_plan(): ] Coverage: %lf\n", fraction);
+
+  res.success = success;
+  show_trail(success);
+  
+  return success;
+
+}
+
+bool VADERPlanner::do_joint_plan(xarm_planner::joint_plan::Request &req, xarm_planner::joint_plan::Response &res)
+{
+  ROS_INFO("move_group_planner received new plan Request");
+  if(!group.setJointValueTarget(req.target))
+  {
+    ROS_ERROR("setJointValueTarget() Failed! Please check the dimension and range of given joint target.");
+    return false;
+  }
+  
+  bool success = (group.plan(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
+  res.success = success;
+  ROS_INFO_NAMED("move_group_planner", "This plan (joint goal) %s", success ? "SUCCEEDED" : "FAILED");
+  show_trail(success);
+  return success;
+}
+
+bool VADERPlanner::exec_plan_cb(xarm_planner::exec_plan::Request &req, xarm_planner::exec_plan::Response &res)
+{
+  if(req.exec)
+  {
+    ROS_INFO("Received Execution Service Request");
+    bool finish_ok = (group.execute(my_xarm_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS); /* return after execution finish */
+    res.success = finish_ok;
+    return finish_ok;
+  }
+
+  res.success = false;
+  return false;
+}
+
+/* execution subscriber call-back function */
+void VADERPlanner::execute_plan_topic(const std_msgs::Bool::ConstPtr& exec)
+{
+  if(exec->data)
+  { 
+    ROS_INFO("Received Execution Command !!!!!");
+    group.asyncExecute(my_xarm_plan); /* return without waiting for finish */
+  }
+}
+
+
+std::string VADERPlanner::PLANNING_GROUP; // Definition of static class member
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "vader_dual_arm_planner");
+  ros::NodeHandle nh;
+  std::string robot_name = "";
+  nh.getParam("robot_name", robot_name);
+  VADERPlanner::PLANNING_GROUP = robot_name;
+
+  VADERPlanner planner;
+
+  planner.start();
+
+  ROS_INFO("Waiting for \'pose_plan\' or \'joint_plan\' service Request ...");
+
+  /* necessary: because AsyncSpinner is not operating in the same thread */
+  ros::waitForShutdown();
+  return 0;
+}
+

--- a/src/vader_planner/srv/exec_plan.srv
+++ b/src/vader_planner/srv/exec_plan.srv
@@ -1,0 +1,3 @@
+bool exec
+---
+bool success

--- a/src/vader_planner/srv/joint_plan.srv
+++ b/src/vader_planner/srv/joint_plan.srv
@@ -1,0 +1,6 @@
+# list of target joint positions in radian.
+float64[] target
+
+---
+
+bool success

--- a/src/vader_planner/srv/pose_plan.srv
+++ b/src/vader_planner/srv/pose_plan.srv
@@ -1,0 +1,5 @@
+geometry_msgs/Pose target
+
+---
+
+bool success

--- a/src/vader_planner/srv/single_straight_plan.srv
+++ b/src/vader_planner/srv/single_straight_plan.srv
@@ -1,0 +1,5 @@
+geometry_msgs/Pose target
+
+---
+
+bool success


### PR DESCRIPTION
Put all planner code (aka launch files and planner node and etc.) into this repository itself, instead of the xarm_ros repo. The launch files still work but now we have our own package, and decouples us from the gigantic codebase of xarm_ros.